### PR TITLE
Adding validation_query_timeout to init manifest and dbconfig for mysql

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,6 +74,7 @@ class jira (
   $pool_max_size                                                    = 20,
   $pool_max_wait                                                    = 30000,
   $validation_query                                                 = undef,
+  $validation_query_timeout                                         = 3,
   $min_evictable_idle_time                                          = 60000,
   $time_between_eviction_runs                                       = undef,
   $pool_max_idle                                                    = 20,

--- a/templates/dbconfig.mysql.xml.erb
+++ b/templates/dbconfig.mysql.xml.erb
@@ -14,6 +14,7 @@
     <pool-max-size><%= scope.lookupvar('jira::pool_max_size') %></pool-max-size>
     <pool-max-wait><%= scope.lookupvar('jira::pool_max_wait') %></pool-max-wait>
     <validation-query><% if @validation_query %><%= @validation_query %><% else %>scope.lookupvar('jira::validation_query')<% end %></validation-query>
+    <validation-query-timeout><%= scope.lookupvar('jira::validation_query_timeout') %></validation-query-timeout>
     <min-evictable-idle-time-millis><%= scope.lookupvar('jira::min_evictable_idle_time') %></min-evictable-idle-time-millis>
     <time-between-eviction-runs-millis><% if @time_between_eviction_runs %><%= @time_between_eviction_runs %><% else %><%= scope.lookupvar('jira::time_between_eviction_runs') %><% end %></time-between-eviction-runs-millis>
     <pool-max-idle><%= scope.lookupvar('jira::pool_max_idle') %></pool-max-idle>


### PR DESCRIPTION
This fixes validation_query_timeout setting not being present in dbconfig.xml on mysql installation.